### PR TITLE
Added $psscriptroot for $CSS

### DIFF
--- a/Private/Generate-Output.ps1
+++ b/Private/Generate-Output.ps1
@@ -39,7 +39,7 @@ function Generate-Output {
             HTML {
                 $ExportBody = [System.Collections.Generic.List[object]]::new()
                 $Content.Values | foreach { $ExportBody.Add(($_ | ConvertTo-Html -Fragment -PreContent "<p>$($_.Name) information for $HostpoolName</p>")) }
-                $Css = Get-Content -Path '.\Private\exportconfig.css' -Raw
+                $Css = Get-Content -Path "$PSScriptRoot\..\Private\exportconfig.css" -Raw
                 $ExportBody = $ExportBody -replace '<td>0</td>', '<td class="WrongStatus">False</td>'
                 $Logo = '<link rel="shortcut icon" href="./Private/wvd-logo.png" />'
                 $style = ("<style>`n") + $Css + ("`n</style>")


### PR DESCRIPTION
Export-WVDConfig resulted in an error, that generate-output could not find the .CSS file..
And exported without CSS layout.

Get-Content : Cannot find path 'C:\temp\test123\Private\exportconfig.css' because it does not exist.
At C:\Program Files\WindowsPowerShell\Modules\az.wvd\1.0.0\Private\Generate-Output.ps1:42 char:24
+ ...            $Css = Get-Content -Path '.\Private\exportconfig.css' -Raw
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\temp\test123\Private\exportconfig.css:String) [Get-Content], ItemNot
   FoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand

